### PR TITLE
PADV-1557 Add storage backend capabilities to SGA Xblock set via platform settings

### DIFF
--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -19,7 +19,6 @@ import pytz
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.core.files import File
-from django.core.files.storage import default_storage
 from django.template import Context, Template
 from django.utils.encoding import force_text
 from django.utils.timezone import now as django_now
@@ -45,6 +44,7 @@ from edx_sga.showanswer import ShowAnswerXBlockMixin
 from edx_sga.tasks import get_zip_file_name, get_zip_file_path, zip_student_submissions
 from edx_sga.utils import (
     file_contents_iter,
+    get_default_storage,
     get_file_modified_time_utc,
     get_file_storage_path,
     get_sha1,
@@ -53,6 +53,8 @@ from edx_sga.utils import (
 )
 
 log = logging.getLogger(__name__)
+
+default_storage = get_default_storage()
 
 
 def reify(meth):

--- a/edx_sga/tasks.py
+++ b/edx_sga/tasks.py
@@ -6,16 +6,17 @@ import os
 import tempfile
 import zipfile
 
-from django.core.files.storage import default_storage
 from celery import shared_task
 from opaque_keys.edx.locator import BlockUsageLocator
 from common.djangoapps.student.models import user_by_anonymous_id
 from submissions import api as submissions_api
 
 from edx_sga.constants import ITEM_TYPE
-from edx_sga.utils import get_file_storage_path, is_finalized_submission
+from edx_sga.utils import get_default_storage, get_file_storage_path, is_finalized_submission
 
 log = logging.getLogger(__name__)
+
+default_storage = get_default_storage()
 
 
 def _get_student_submissions(block_id, course_id, locator):

--- a/edx_sga/tests/test_utils.py
+++ b/edx_sga/tests/test_utils.py
@@ -1,11 +1,14 @@
 """
 Tests for SGA utility functions
 """
+from django.test import override_settings
+from django.core.files.storage import default_storage
 import pytest
 import pytz
+from storages.backends.s3boto3 import S3Boto3Storage
 
 from edx_sga.tests.common import is_near_now
-from edx_sga.utils import is_finalized_submission, utcnow
+from edx_sga.utils import get_default_storage, is_finalized_submission, utcnow
 
 
 @pytest.mark.parametrize(
@@ -31,3 +34,24 @@ def test_utcnow():
     now = utcnow()
     assert is_near_now(now)
     assert now.tzinfo.zone == pytz.utc.zone
+
+@override_settings(SGA_STORAGE_SETTINGS={
+        'STORAGE_CLASS': 'storages.backends.s3boto3.S3Boto3Storage',
+        'STORAGE_KWARGS':
+            {'bucket_name': 'test', 'location': 'abc/def'}
+    })
+def test_get_default_storage_with_settings_override():
+    """
+    get_default_storage should return an S3Boto3Storage object
+    """
+    storage = get_default_storage()
+    assert storage.__class__ == S3Boto3Storage
+    # make sure kwargs are passed through constructor
+    assert storage.bucket.name == 'test'
+
+def test_get_default_storage_without_settings_override():
+    """
+    get_default_storage should return default_storage object
+    """
+    storage = get_default_storage()
+    assert storage == default_storage

--- a/edx_sga/utils.py
+++ b/edx_sga/utils.py
@@ -9,9 +9,33 @@ from functools import partial
 
 import pytz
 from django.conf import settings
-from django.core.files.storage import default_storage
+from django.core.files.storage import default_storage as django_default_storage, get_storage_class
 from edx_sga.constants import BLOCK_SIZE
 
+
+def get_default_storage():
+    """
+    Get config for storage from settings, use Django's default_storage if no such settings are defined
+    """
+    # .. setting_name: SGA_STORAGE_SETTINGS
+    # .. setting_default: {}
+    # .. setting_description: Specifies the storage class and keyword arguments to use in the constructor
+    #    Default storage will be used if this settings in not specified.
+    # .. setting_example: {
+    #        STORAGE_CLASS: 'storage',
+    #        STORAGE_KWARGS: {}
+    #    }
+    sga_storage_settings = getattr(settings, "SGA_STORAGE_SETTINGS", None)
+
+    if sga_storage_settings:
+        return get_storage_class(
+            sga_storage_settings['STORAGE_CLASS']
+        )(**sga_storage_settings['STORAGE_KWARGS'])
+
+    # If settings not defined, use default_storage from Django
+    return django_default_storage
+
+default_storage = get_default_storage()
 
 def utcnow():
     """

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,11 +1,11 @@
 # maintain the latest version
-celery==5.0.6
-codecov==2.1.10
-coverage==5.3
-cryptography==3.3.2
-ddt==1.4.2
-djangorestframework==3.12.4
-edx-celeryutils==1.1.0
+celery==5.3.0
+coverage==7.2.7
+cryptography==41.0.1
+ddt==1.6.0
+djangorestframework
+django-storages
+edx-celeryutils==1.2.2
 edx-lint==5.2.4
 edx-opaque-keys
 edx-submissions==3.3.1


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-1557

## Description
This PR add the feature to the SGA Xblock to be able to manage different storage backend definitions via platform settings. If there are not settings, it would relay on Django's default storage. 

## Changes Made

- [x] Override actual definition of used storage into the Xblock SGA module
- [x] Create custom backend that provides interface for the Xblock to use an storage defined. 

## How To Test

- Please follow [Xblock's doc](https://github.com/Pearson-Advance/edx-sga?tab=readme-ov-file#staff-graded-assignment-xblock) to use the SGA as it used to work, nothing shall change in terms of user experience when uploading or downloading files. 
- Through the platform settings, set the following settings format using the keys provided by AWS S3 for a given bucket. 
```
"SGA_STORAGE_SETTINGS": {
"STORAGE_CLASS": "your.desire.storage.backend,
"STORAGE_KWARGS":  {
      "key": "value"
  }
}
```
- Files shall be processed thru the desite storage. 

## Annotations

### Broken dependencies and CI process
CI process of unit testing and linting is failing due to dependencies issues. It also restrict the possibility to run it locally despite of the presence of a Tox defined workflow to do so. This is because it expects the workflows and credentails from upstream, not pearson. That could be cover in future PRs, but is not the purpose of this one so it won't be reviewed.

### Lack of openedx_wrapper

As you might realize, the openedx site configurations helper is import directly into the SGA module without the use of a wrapper, which conflicts with our code quality standards. This is because most of the platform imports are doing in the same way and looking forward to port this in the upstream repository we shall not use any different approach but the one the repository has. 

### Upstream port

This feature is a port coming from the [upstream repository](https://github.com/mitodl/edx-sga/pull/344) 
Testing cases and feature documentation would be available in next PR where we adjust the upstream feature to the site-awareness desire behavior of the Xblock