### PR TITLE
PADV-1558 Pull Storage definition from site configuration each time there would be a file process 

### DIFF
--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -54,8 +54,6 @@ from edx_sga.utils import (
 
 log = logging.getLogger(__name__)
 
-default_storage = get_default_storage()
-
 
 def reify(meth):
     """
@@ -285,6 +283,7 @@ class StaffGradedAssignmentXBlock(
             path,
             user.username,
         )
+        default_storage = get_default_storage()
         if default_storage.exists(path):
             # save latest submission
             default_storage.delete(path)
@@ -330,6 +329,7 @@ class StaffGradedAssignmentXBlock(
         state["annotated_mimetype"] = mimetypes.guess_type(upload.file.name)[0]
         state["annotated_timestamp"] = utcnow().strftime(DateTime.DATETIME_FORMAT)
         path = self.file_storage_path(sha1, filename)
+        default_storage = get_default_storage()
         if not default_storage.exists(path):
             default_storage.save(path, File(upload.file))
         module.state = json.dumps(state)
@@ -614,6 +614,7 @@ class StaffGradedAssignmentXBlock(
         used, the block's "clear_student_state" function is called if it exists.
         """
         student_id = kwargs["user_id"]
+        default_storage = get_default_storage()
         for submission in submissions_api.get_submissions(
             self.get_student_item_dict(student_id)
         ):
@@ -979,7 +980,7 @@ class StaffGradedAssignmentXBlock(
         zip_file_path = get_zip_file_path(
             user.username, self.block_course_id, self.block_id, self.location
         )
-        return default_storage.exists(zip_file_path)
+        return get_default_storage().exists(zip_file_path)
 
     def count_archive_files(self, user):
         """
@@ -989,7 +990,7 @@ class StaffGradedAssignmentXBlock(
         zip_file_path = get_zip_file_path(
             user.username, self.block_course_id, self.block_id, self.location
         )
-        with default_storage.open(zip_file_path, "rb") as zip_file:
+        with get_default_storage().open(zip_file_path, "rb") as zip_file:
             with closing(ZipFile(zip_file)) as archive:
                 return len(archive.infolist())
 

--- a/edx_sga/tasks.py
+++ b/edx_sga/tasks.py
@@ -16,8 +16,6 @@ from edx_sga.utils import get_default_storage, get_file_storage_path, is_finaliz
 
 log = logging.getLogger(__name__)
 
-default_storage = get_default_storage()
-
 
 def _get_student_submissions(block_id, course_id, locator):
     """
@@ -66,6 +64,7 @@ def _compress_student_submissions(zip_file_path, block_id, course_id, locator):
         zip_file_path,
     )
     # Build the zip file in memory using temporary file.
+    default_storage = get_default_storage()
     with tempfile.TemporaryFile() as tmp:
         with zipfile.ZipFile(tmp, "w", compression=zipfile.ZIP_DEFLATED) as zip_pointer:
             for student_username, submission_file_path in student_submissions:
@@ -100,6 +99,7 @@ def zip_student_submissions(course_id, block_id, locator_unicode, username):
     locator = BlockUsageLocator.from_string(locator_unicode)
     zip_file_path = get_zip_file_path(username, course_id, block_id, locator)
     log.info("Creating zip file for course: %s at path: %s", locator, zip_file_path)
+    default_storage = get_default_storage()
     if default_storage.exists(zip_file_path):
         log.info("Deleting already-existing zip file at path: %s", zip_file_path)
         default_storage.delete(zip_file_path)

--- a/edx_sga/utils.py
+++ b/edx_sga/utils.py
@@ -8,6 +8,7 @@ import time
 from functools import partial
 
 import pytz
+from django.conf import settings
 from django.core.files.storage import default_storage as django_default_storage, get_storage_class
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from edx_sga.constants import BLOCK_SIZE


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-1558

## Description
This PR removes the storage definition from when the xblock is initialized in the platform and instead, checks the storage definition each time there would be a file action such uploads, downloads, etc. 

## Changes Made

- [x] Remove storage definition prior to Xblock package being initialized
- [x] Add storage definition pull each time a method would process a file request

## How To Test

- Please follow [Xblock's doc](https://github.com/Pearson-Advance/edx-sga?tab=readme-ov-file#staff-graded-assignment-xblock) to use the SGA as it used to work, nothing shall change in terms of user experience when uploading or downloading files. 
- Through the site configuration, set the following settings format using the keys provided by AWS S3 for a given bucket. 
```
"SGA_STORAGE_SETTINGS": {
    "STORAGE_CLASS": "your.desire.storage.backend,
    "STORAGE_KWARGS":  {
        "key": "value"
    }
}
```
- If possible, add a print statement [here](https://github.com/Pearson-Advance/edx-sga/blob/67004c67f9c8f6d7a0db2cc69bf1243b650282d1/edx_sga/utils.py#L30) and confirms that the storage definition is checked each time there would be a file process like [this upload method](https://github.com/Pearson-Advance/edx-sga/blob/67004c67f9c8f6d7a0db2cc69bf1243b650282d1/edx_sga/sga.py#L254) 
- Files shall be processed thru the desire storage. 

## Annotations

### Broken dependencies and CI process
CI process of unit testing and linting is failing due to dependencies issues. It also restrict the possibility to run it locally despite of the presence of a Tox defined workflow to do so. This is because it expects the workflows and credentials from upstream, not pearson. That could be cover in future PRs, but is not the purpose of this one so it won't be reviewed.

### Unit Testing
As per the missing dependencies and challenges with Tox definition, the unit testing shall be executed thru the paltaform shell. More documentation about it can be found [here](https://github.com/mitodl/edx-sga?tab=readme-ov-file#testing).  