### PR TITLE
PADV-1558 add default storage instances on utils.py

### DIFF
--- a/edx_sga/utils.py
+++ b/edx_sga/utils.py
@@ -36,8 +36,6 @@ def get_default_storage():
     # If settings not defined, use default_storage from Django
     return django_default_storage
 
-default_storage = get_default_storage()
-
 def utcnow():
     """
     Get current date and time in UTC
@@ -67,7 +65,7 @@ def get_file_modified_time_utc(file_path):
         else pytz.utc
     )
 
-    file_time = default_storage.get_modified_time(file_path)
+    file_time = get_default_storage().get_modified_time(file_path)
 
     if file_time.tzinfo is None:
         return file_timezone.localize(file_time).astimezone(pytz.utc)
@@ -99,5 +97,5 @@ def file_contents_iter(file_path):
     """
     Returns an iterator over the contents of a file located at the given file path
     """
-    file_descriptor = default_storage.open(file_path)
+    file_descriptor = get_default_storage().open(file_path)
     return iter(partial(file_descriptor.read, BLOCK_SIZE), b"")


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-1558

## Description
This PR add a feature to utils.py to recalculate the storage to be used instead of prior defining when the platform is initialized  

## Changes Made

- [x] Remove storage definition prior to Xblock package being initialized
- [x] Add storage definition pull on utils.py

## How To Test

- Please follow [Xblock's doc](https://github.com/Pearson-Advance/edx-sga?tab=readme-ov-file#staff-graded-assignment-xblock) to use the SGA as it used to work, nothing shall change in terms of user experience when uploading or downloading files. 
- Through the site configuration, set the following settings format using the keys provided by AWS S3 for a given bucket. 
```
"SGA_STORAGE_SETTINGS": {
    "STORAGE_CLASS": "your.desire.storage.backend,
    "STORAGE_KWARGS":  {
        "key": "value"
    }
}
```
- If possible, add a print statement [here](https://github.com/Pearson-Advance/edx-sga/blob/67004c67f9c8f6d7a0db2cc69bf1243b650282d1/edx_sga/utils.py#L99) and confirms that the storage definition is checked when the files are being downloaded 
## Annotations

### Broken dependencies and CI process
CI process of unit testing and linting is failing due to dependencies issues. It also restrict the possibility to run it locally despite of the presence of a Tox defined workflow to do so. This is because it expects the workflows and credentials from upstream, not pearson. That could be cover in future PRs, but is not the purpose of this one so it won't be reviewed.

### Unit Testing
As per the missing dependencies and challenges with Tox definition, the unit testing shall be executed thru the paltaform shell. More documentation about it can be found [here](https://github.com/mitodl/edx-sga?tab=readme-ov-file#testing).  