### PR TITLE
PADV-2022 set STUDENT_FILEUPLOAD_MAX_SIZE via site configurations

### DIFF
--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -27,6 +27,7 @@ from lms.djangoapps.courseware.models import StudentModule
 from openedx.core.lib.safe_lxml import etree
 from common.djangoapps.student.models import user_by_anonymous_id
 from ccx_keys.locator import CCXLocator
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from submissions import api as submissions_api
 from submissions.models import StudentItem as SubmissionsStudent
 from submissions.models import Submission
@@ -165,9 +166,10 @@ class StaffGradedAssignmentXBlock(
         """
         returns max file size limit in system
         """
-        return getattr(
-            settings, "STUDENT_FILEUPLOAD_MAX_SIZE", cls.STUDENT_FILEUPLOAD_MAX_SIZE
-        )
+        return configuration_helpers.get_value("STUDENT_FILEUPLOAD_MAX_SIZE", getattr(
+            settings, "STUDENT_FILEUPLOAD_MAX_SIZE",
+            cls.STUDENT_FILEUPLOAD_MAX_SIZE,
+        ))
 
     @classmethod
     def file_size_over_limit(cls, file_obj):


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-2022

## Description

This PR adds the feature to set via site configurations the maximum file size to be accepted for the attachments to be uploaded. If not limit has been set, it would take the one set by the platform as it used to do.

## Changes Made

[x] Pull the STUDENT_FILEUPLOAD_MAX_SIZE site configurations and checks file size in the Xblock.
[x] Set the file size defined either by site configurations or platform setting


## How To Test

1. Set the site configuration as `STUDENT_FILEUPLOAD_MAX_SIZE':  1400000000` where 1400000000 is a byte expressed value of the desire max size. In this case is ~1.4GB
2. Confirms that the Xblock allows upload files with a size less than 1.4GB

## Annotations

### Broken dependencies and CI process
CI process of unit testing and linting is failing due to dependencies issues. It also restrict the possibility to run it locally despite of the presence of a Tox defined workflow to do so. This is because it expects the workflows and credentials from upstream, not pearson. That could be cover in future PRs, but is not the purpose of this one so it won't be reviewed.

### Unit Testing
As per the missing dependencies and challenges with Tox definition, the unit testing shall be executed thru the platform shell. More documentation about it can be found [here](https://github.com/mitodl/edx-sga?tab=readme-ov-file#testing).  